### PR TITLE
Fix: Check if 'dale_ratio' is part of saved weights

### DIFF
--- a/psychrnn/backend/initializations.py
+++ b/psychrnn/backend/initializations.py
@@ -62,8 +62,12 @@ class WeightInitializer(object):
             # Load saved weights
             # ----------------------------------
             self.initializations = dict(np.load(self.load_weights_path, allow_pickle = True))
-            if type(self.initializations['dale_ratio']) == np.ndarray:
-                self.initializations['dale_ratio'] = self.initializations['dale_ratio'].item()
+            if 'dale_ratio' in self.initializations.keys():
+                if type(self.initializations['dale_ratio']) == np.ndarray:
+                    self.initializations['dale_ratio'] = self.initializations['dale_ratio'].item()
+            else:
+                warn("You are loading weights from a model trained with an old version (<1.0)")
+                self.initializations['dale_ratio']  = None;
 
         else:
             if kwargs.get('W_rec', None) is None and type(self).__name__=='WeightInitializer':


### PR DESCRIPTION
Without this check, loading pre-v1.0 weights can make an error.