### PR TITLE
update in get_effective_W_out

### DIFF
--- a/psychrnn/backend/rnn.py
+++ b/psychrnn/backend/rnn.py
@@ -329,7 +329,7 @@ class RNN(ABC):
 
         W_out = self.W_out * self.output_connectivity
         if self.dale_ratio:
-            W_out = tf.matmul(tf.abs(self.W_out), self.Dale_out, name="in_2")
+            W_out = tf.matmul(tf.abs(W_out), self.Dale_out, name="in_2")
         return W_out
     
     @abstractmethod


### PR DESCRIPTION
Hello, 
I'm using PsychRNN for a project and I set some of the output-connectivity to 0, but I noticed that didn't translate into the weights by setting them to 0 as well, which it did for the input and recurrent matrix. So I looked into your code and found that you use self.W_out instead of W_out when defining W_out so that ignores the previous multiplication with output_connectivity matrix. And both W_in and W_rec are defined with tf.abs(W_in/W_out) and they work fine.  Anyway I'm a very unexperienced coder, I hope that change doesn't ruin anything. And thank you for this package it's really helping me out with my masters project ! 
Best 
Isabelle