### PR TITLE
v1.0.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Paper:**
 
-Ehrlich, D. B.<sup>\*</sup>, Stone, J. T.<sup>\*</sup>, Brandfonbrener, D., Atanasov, A., & Murray, J. D. (2021). PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. ENeuro, 8(1). [\[DOI\]](https://doi.org/10.1523/ENEURO.0427-20.2020)
+Ehrlich, D. B.<sup>\*</sup>, Stone, J. T.<sup>\*</sup>, Brandfonbrener, D., Atanasov, A., & Murray, J. D. (2021). PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. *ENeuro, 8*(1). [\[DOI\]](https://doi.org/10.1523/ENEURO.0427-20.2020)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 [![codecov](https://codecov.io/gh/murraylab/PsychRNN/branch/master/graph/badge.svg)](https://codecov.io/gh/murraylab/PsychRNN)
 [![Documentation Status](https://readthedocs.org/projects/psychrnn/badge/?version=latest)](https://psychrnn.readthedocs.io/en/latest/?badge=latest)
 
-**Preprint:**
-
-Ehrlich DB<sup>\*</sup>, Stone JT<sup>\*</sup>, Brandfonbrener D, Atanasov A, Murray JD (2020) PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. *bioRxiv* 10.1101/2020.09.30.321752. [\[DOI\]](https://doi.org/10.1101/2020.09.30.321752)
+**Paper:**
+Ehrlich, D. B.<sup>\*</sup>, Stone, J. T.<sup>\*</sup>, Brandfonbrener, D., Atanasov, A., & Murray, J. D. (2021). PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. ENeuro, 8(1). [\[DOI\]](https://doi.org/10.1523/ENEURO.0427-20.2020)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Documentation Status](https://readthedocs.org/projects/psychrnn/badge/?version=latest)](https://psychrnn.readthedocs.io/en/latest/?badge=latest)
 
 **Paper:**
+
 Ehrlich, D. B.<sup>\*</sup>, Stone, J. T.<sup>\*</sup>, Brandfonbrener, D., Atanasov, A., & Murray, J. D. (2021). PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. ENeuro, 8(1). [\[DOI\]](https://doi.org/10.1523/ENEURO.0427-20.2020)
 
 ## Overview

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3,4 +3,4 @@ Reference
 
 If you use PsychRNN in your research, please cite the following paper:
 
-- Ehrlich, D. B.*, Stone, J. T.*, Brandfonbrener, D., Atanasov, A., & Murray, J. D. (2021). PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. *ENeuro, 8*(1). `https://doi.org/10.1523/ENEURO.0427-20.2020 <https://doi.org/10.1523/ENEURO.0427-20.2020>`_.
+- Ehrlich, D. B.*, Stone, J. T.*, Brandfonbrener, D., Atanasov, A., & Murray, J. D. (2021). PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. *ENeuro, 8*\ (1). `https://doi.org/10.1523/ENEURO.0427-20.2020 <https://doi.org/10.1523/ENEURO.0427-20.2020>`_.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3,4 +3,4 @@ Reference
 
 If you use PsychRNN in your research, please cite the following paper:
 
-- Ehrlich, D. B.*, Stone, J. T.*, Brandfonbrener, D., Atanasov, A., & Murray, J. D. (2021). PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. ENeuro, 8(1). `https://doi.org/10.1523/ENEURO.0427-20.2020 <https://doi.org/10.1523/ENEURO.0427-20.2020>`_.
+- Ehrlich, D. B.*, Stone, J. T.*, Brandfonbrener, D., Atanasov, A., & Murray, J. D. (2021). PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. *ENeuro, 8*(1). `https://doi.org/10.1523/ENEURO.0427-20.2020 <https://doi.org/10.1523/ENEURO.0427-20.2020>`_.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,6 +1,6 @@
 Reference
 ==================
 
-If you use PsychRNN in your research, please cite the following preprint:
+If you use PsychRNN in your research, please cite the following paper:
 
-- Ehrlich DB*, Stone JT*, Brandfonbrener D, Atanasov A, Murray JD (2020) PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. bioRxiv `10.1101/2020.09.30.321752 <https://doi.org/10.1101/2020.09.30.321752>`_.
+- Ehrlich, D. B.*, Stone, J. T.*, Brandfonbrener, D., Atanasov, A., & Murray, J. D. (2021). PsychRNN: An Accessible and Flexible Python Package for Training Recurrent Neural Network Models on Cognitive Tasks. ENeuro, 8(1). `https://doi.org/10.1523/ENEURO.0427-20.2020 <https://doi.org/10.1523/ENEURO.0427-20.2020>`_.

--- a/psychrnn/_version.py
+++ b/psychrnn/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-alpha"
+__version__ = "1.0.0"


### PR DESCRIPTION
This is the stable v1.0.0 release. Below is a summary of changes and updates from the alpha pre-release of v1.0.0. For updates since v0.4, see the [pre-release notes](https://github.com/murraylab/PsychRNN/releases/tag/v1.0.0-alpha).

Thank you to the following users who contributed patches: 
* Isabelle Garnreiter (@isagarnreiter)
* Michael Berger (@bergem1t)

Thank you also to Alex Williams (@ahwillia) for suggesting adding an example with fixed random seeds to the documentation.

# New Features
* Add references to our [published paper](https://www.eneuro.org/content/8/1/ENEURO.0427-20.2020)!
* Add logo to readthedocs
* Add setting seeds demonstration to Simple Example (#26)

# Bug Fixes
* Make backwards compatible with previous weights formats (#24)
* Fix Simple Example so saving weights works in collab.
* Fix bug in get_effective_W_out when using output_connectivity.