### PR TITLE
fix stop condition for epochs

### DIFF
--- a/psychrnn/backend/rnn.py
+++ b/psychrnn/backend/rnn.py
@@ -548,7 +548,7 @@ class RNN(ABC):
         if performance_cutoff is not None:
             performance = performance_cutoff - 1
 
-        while epoch * batch_size < training_iters and (performance_cutoff is None or performance < performance_cutoff):
+        while epoch * batch_size <= training_iters and (performance_cutoff is None or performance < performance_cutoff):
             batch_x, batch_y, output_mask, _ = next(trial_batch_generator)
             self.sess.run(optimize, feed_dict={self.x: batch_x, self.y: batch_y, self.output_mask: output_mask})
             # --------------------------------------------------

--- a/psychrnn/backend/rnn.py
+++ b/psychrnn/backend/rnn.py
@@ -548,7 +548,7 @@ class RNN(ABC):
         if performance_cutoff is not None:
             performance = performance_cutoff - 1
 
-        while epoch * batch_size <= training_iters and (performance_cutoff is None or performance < performance_cutoff):
+        while (epoch - 1) * batch_size < training_iters and (performance_cutoff is None or performance < performance_cutoff):
             batch_x, batch_y, output_mask, _ = next(trial_batch_generator)
             self.sess.run(optimize, feed_dict={self.x: batch_x, self.y: batch_y, self.output_mask: output_mask})
             # --------------------------------------------------

--- a/test/backend/test_rnn.py
+++ b/test/backend/test_rnn.py
@@ -254,7 +254,7 @@ def test_train_iters(tf_graph, mocker, capfd):
 		rnn.destruct()
 
 		out, _ = capfd.readouterr()
-		N_epochs = ceil(train_params['training_iters'] / params['N_batch'])
+		N_epochs = int(ceil(train_params['training_iters'] / (params['N_batch'] * 1.0)))
 		assert "Iter " + str(N_epochs * params['N_batch']) in out
 		assert "Iter " + str((N_epochs+1) * params['N_batch']) not in out
 


### PR DESCRIPTION
`epoch` starts at 1, so `<` leads to one fewer epoch than expected