### PR TITLE
Fix hardcoding and make mask and output line up.

### DIFF
--- a/psychrnn/tasks/perceptual_discrimination.py
+++ b/psychrnn/tasks/perceptual_discrimination.py
@@ -112,7 +112,7 @@ class PerceptualDiscrimination(Task):
             x_t[dir] += 1 + coh
             x_t[(dir + 1) % 2] += 1
 
-        if t > onset + stim_dur + 20:
+        if t >= onset + stim_dur:
             y_t[dir] = self.hi
             y_t[1-dir] = self.lo
 


### PR DESCRIPTION
Previously, there was a hard coded delay between the end of the stimulus and the beginning of the output, but the mask started having the network match the output when the stimulus turned off.