### PR TITLE
fix batch generator in a task

### DIFF
--- a/psychrnn/backend/curriculum.py
+++ b/psychrnn/backend/curriculum.py
@@ -145,11 +145,20 @@ class Curriculum(object):
 			return True
 		return False
 
-	def get_generator_function(self):
-		""" Return the generator function for the current task.
+	def batch_generator(self):
+		""" Generates a batch of trials of the current task.
 
-		Returns:
-			:func:`psychrnn.tasks.task.Task.batch_generator` function: Task batch generator for the task at the current stage.
-		"""
+        Returns:
+            Generator[tuple, None, None]: generator iterator for the current task
+
+        Yields:
+            tuple:
+
+            * **stimulus** (*ndarray(dtype=float, shape =(*:attr:`N_batch`, :attr:`N_steps`, :attr:`N_out` *))*): Task stimuli for :attr:`N_batch` trials.
+            * **target_output** (*ndarray(dtype=float, shape =(*:attr:`N_batch`, :attr:`N_steps`, :attr:`N_out` *))*): Target output for the network on :attr:`N_batch` trials given the :data:`stimulus`.
+            * **output_mask** (*ndarray(dtype=bool, shape =(*:attr:`N_batch`, :attr:`N_steps`, :attr:`N_out` *))*): Output mask for :attr:`N_batch` trials. True when the network should aim to match the target output, False when the target output can be ignored.
+            * **trial_params** (*ndarray(dtype=dict, shape =(*:attr:`N_batch` *,))*): Array of dictionaries containing the trial parameters produced by :func:`generate_trial_params` for each trial in :attr:`N_batch`.
+        
+        """
 		return self.tasks[self.stage].batch_generator()
 

--- a/psychrnn/backend/rnn.py
+++ b/psychrnn/backend/rnn.py
@@ -486,7 +486,7 @@ class RNN(ABC):
                 raise UserWarning("training will not be cutoff based on performance. Make sure both performance_measure and performance_cutoff are defined")
 
         if curriculum is not None:
-            trial_batch_generator = curriculum.get_generator_function()
+            trial_batch_generator = curriculum.batch_generator()
 
         if not isgenerator(trial_batch_generator):
             trial_batch_generator = trial_batch_generator.batch_generator()
@@ -574,7 +574,7 @@ class RNN(ABC):
                 if curriculum.metric_test(trial_batch, trial_y, output_mask, output, epoch, losses, verbosity):
                     if curriculum.stop_training:
                         break
-                    trial_batch_generator = curriculum.get_generator_function()
+                    trial_batch_generator = curriculum.batch_generator()
 
             # --------------------------------------------------
             # Save intermediary weights

--- a/psychrnn/tasks/task.py
+++ b/psychrnn/tasks/task.py
@@ -52,6 +52,9 @@ class Task(ABC):
         self.alpha = (1.0 * self.dt) / self.tau
         self.N_steps = int(np.ceil(self.T / self.dt))
 
+        # Initialize a generator
+        self._batch_generator = self.batch_generator()
+
     def get_task_params(self):
         """ Get dictionary of task parameters.
 
@@ -225,7 +228,7 @@ class Task(ABC):
     def get_trial_batch(self):
         """Get a batch of trials.
 
-        Wrapper for :code:`next(self.batch_generator())`.
+        Wrapper for :code:`next(self._batch_generator)`.
 
         Returns:
             tuple:
@@ -236,5 +239,5 @@ class Task(ABC):
             * **trial_params** (*ndarray(dtype=dict, shape =(*:attr:`N_batch` *,))*): Array of dictionaries containing the trial parameters produced by :func:`generate_trial_params` for each trial in :attr:`N_batch`.
 
         """
-        return next(self.batch_generator())
+        return next(self._batch_generator)
 


### PR DESCRIPTION
fixing #42 by reusing a generator object in a task

also making the `batch_generator` method in a curriculum consistent with that in a task