### PR TITLE
fix test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,16 +22,18 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
-        TF: [None, 1.13.1, 1.14, 1.15, 2.0, 2.1, 2.2]
+        TF: [1.13.1, 1.14, 1.15, 2.0, 2.1, 2.2, 2.*]
         exclude:
         - python-version: 2.7
-          TF: None
+          TF: 2.*
         - python-version: 3.5
-          TF: None
+          TF: 2.*
         - python-version: 3.6
-          TF: None
+          TF: 2.*
         - python-version: 2.7
           TF: 2.2
+        - python-version: 3.7
+          TF: 2.0
         - python-version: 3.8
           TF: 1.13.1
         - python-version: 3.8
@@ -58,14 +60,10 @@ jobs:
         pip install pytest_cov
         pip install codecov 
     - name: Install package dependencies with TF ${{ matrix.TF }}
-      if: ${{ matrix.TF != 'None' }}
       run: |
-        pip install numpy
-        pip install tensorflow==${{ matrix.TF }}
+        pip install numpy tensorflow==${{ matrix.TF }} 'protobuf<=3.20'
         export PYTHONPATH=$PYTHONPATH:$(pwd)
-        python setup.py install
-    - name: Install package dependencies from setup.py
-      if: ${{ matrix.TF == 'None' }}
+    - name: Install this package
       run: |
         python setup.py install
     - name: Test with pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
@@ -46,9 +46,9 @@ jobs:
           TF: 2.1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install test dependencies


### PR DESCRIPTION
fix #39 
- using older version of `protobuf`
- removing the combination of python3.7 & tf 2.0

Also updating deprecated Github Action environments

Btw, [TensorFlow follows Semantic Versioning](https://www.tensorflow.org/guide/versions) so it may not be necessary to specify all versions for testing.