### PR TITLE
set numpy version in tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
-        TF: [1.13.1, 1.14, 1.15, 2.0, 2.1, 2.2]
+        TF: [1.13.1, 1.14, 1.15, 2.0, 2.1, 2.2, 2.*]
         exclude:
         - python-version: 2.7
           TF: 2.2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,16 +22,18 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
-        TF: [None, 1.13.1, 1.14, 1.15, 2.0, 2.1, 2.2]
+        TF: [1.13.1, 1.14, 1.15, 2.0, 2.1, 2.2, 2.*]
         exclude:
         - python-version: 2.7
-          TF: None
+          TF: 2.*
         - python-version: 3.5
-          TF: None
+          TF: 2.*
         - python-version: 3.6
-          TF: None
+          TF: 2.*
         - python-version: 2.7
           TF: 2.2
+        - python-version: 3.7
+          TF: 2.0
         - python-version: 3.8
           TF: 1.13.1
         - python-version: 3.8
@@ -58,14 +60,10 @@ jobs:
         pip install pytest_cov
         pip install codecov 
     - name: Install package dependencies with TF ${{ matrix.TF }}
-      if: ${{ matrix.TF != 'None' }}
       run: |
-        pip install numpy
-        pip install tensorflow==${{ matrix.TF }}
+        pip install numpy tensorflow==${{ matrix.TF }} 'protobuf<=3.20'
         export PYTHONPATH=$PYTHONPATH:$(pwd)
-        python setup.py install
-    - name: Install package dependencies from setup.py
-      if: ${{ matrix.TF == 'None' }}
+    - name: Install this package
       run: |
         python setup.py install
     - name: Test with pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,14 +22,8 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
-        TF: [1.13.1, 1.14, 1.15, 2.0, 2.1, 2.2, 2.*]
+        TF: [1.13.1, 1.14, 1.15, 2.0, 2.1, 2.2]
         exclude:
-        - python-version: 2.7
-          TF: 2.*
-        - python-version: 3.5
-          TF: 2.*
-        - python-version: 3.6
-          TF: 2.*
         - python-version: 2.7
           TF: 2.2
         - python-version: 3.7
@@ -61,7 +55,7 @@ jobs:
         pip install codecov 
     - name: Install package dependencies with TF ${{ matrix.TF }}
       run: |
-        pip install numpy tensorflow==${{ matrix.TF }} 'protobuf<=3.20'
+        pip install 'numpy<1.24' tensorflow==${{ matrix.TF }} 'protobuf<=3.20'
         export PYTHONPATH=$PYTHONPATH:$(pwd)
     - name: Install this package
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
@@ -46,9 +46,9 @@ jobs:
           TF: 2.1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install test dependencies


### PR DESCRIPTION
Recent numpy 1.24 deprecated some apis, breaking compatibilty with TF. So I added a constrain to numpy version in tests. I also removed the wildcard for TF v2, since recent versions seem to introduce some breaking changes.