### PR TITLE
fix invalid specifier that was breaking example notebooks & pip-installing from GitHub/sdist. Also update readthedocs configuration files and remove testing on python 2.7 due to breaking changes in readthedocs and GitHub actions.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         TF: [1.13.1, 1.14, 1.15, 2.0, 2.1, 2.2, 2.*]
         exclude:
         - python-version: 2.7

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,3 +22,4 @@ sphinx:
 python:
   install:
   - requirements: docs/requirements.txt
+  - method: setuptools

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,3 +23,4 @@ python:
   install:
   - requirements: docs/requirements.txt
   - method: setuptools
+    path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
-  configuration: conf.py
+  configuration: docs/conf.py
   fail_on_warning: true
 
 # We recommend specifying your dependencies to enable reproducible builds:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,12 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  builder: html
+  configuration: conf.py
+  fail_on_warning: true
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ extensions = [
   'sphinx.ext.mathjax',
   'sphinx_copybutton',
   "sphinx_rtd_theme",
-  'sphinxcontrib.napoleon',
+  'sphinx.ext.napoleon',
   'autodocsumm',
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx>=3.0.4
+sphinx_rtd_theme
 ipykernel
 nbsphinx
 sphinx_copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx>=3.0.4
-sphinx_rtd_theme
+sphinx_rtd_theme==1.1.1
 ipykernel
 nbsphinx
 sphinx_copybutton

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     'Mailing List': 'https://www.freelists.org/list/psychrnn',
     },
 
-    install_requires=['python_version>="2.7",!="3.0*",!="3.1*",!="3.2*",!="3.3*"', 'tensorflow']
+    install_requires=['tensorflow'],
+    python_requires='>=2.7, !=3.0, !=3.1, !=3.2, !=3.3'
 
 )


### PR DESCRIPTION
Hi all, thanks for creating such a useful package!

Noticed during @johndmurray's guest lecture in [torwager/ComputationalFoundations](https://github.com/torwager/ComputationalFoundations) that the [Minimal Example](https://colab.research.google.com/github/murraylab/PsychRNN/blob/master/docs/notebooks/Minimal_Example.ipynb) and [Simple Example](https://colab.research.google.com/github/murraylab/PsychRNN/blob/master/docs/notebooks/PerceptualDiscrimination.ipynb) Colab notebooks are broken. Installing `PsychRNN` from the GitHub repo in the first cell fails because the version specifier after "`python_version`" in this line is invalid:
https://github.com/murraylab/PsychRNN/blob/2f5415534de786b2901fd3b5914d94c94a0f68fa/setup.py#L29

#

The reason the example notebooks were working fine previously (and regular `pip install PsychRNN` is still working **for now**) is actually a little convoluted -- 

When building a package from a source distribution (e.g., the GitHub repo), old versions of `setuptools` (prior to `v61.0`) would simply ignore invalid specifiers rather than throwing an error. The Colab VM had an older `setuptools` version installed back when the example notebooks were written, so at that point the invalid specifier in `PsychRNN/setup.py` was just getting ignored. But when Colab's `setuptools` installation was [finally updated back in March 2023](https://colab.research.google.com/notebooks/relnotes.ipynb#scrollTo=Duo3MBudqBX1&line=24) (it's now at `v67.7.2`), the example notebooks suddenly broke because that line in `setup.py` started preventing the package from being successfully built from the repo.

The reason that ignoring the invalid specifier like `setuptools` used to do actually caused things to work right is kind of a happy accident. Ignoring the specifier makes that line in `setup.py` read:
```python
install_requires=['python_version', 'tensorflow'] 
```
Items passed to [`install_requires`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#install-requires) are names of **packages** that the current package depends on. So rather than specifying what version(s) of *Python itself* the `PsychRNN` package requires (which I think was the intent based on the [README](https://github.com/murraylab/PsychRNN#dependencies)), passing `'python_version'` to `install_requires` actually means "*This package requires a package named `python_version`*". 

Just by chance, there actually happens to be [a package named "`python_version`"](https://pypi.org/project/python_version/) available on PyPI, so `PsychRNN` has been installing the "`python_version`" package as a dependency rather than checking for the Python versions it actually requires.

Finally, the reason you *can* still successfully install `PsychRNN` from PyPI with `pip install PsychRNN` *for the moment* is that the package is [available on PyPI](https://pypi.org/project/PsychRNN/#files) as a binary distribution (a.k.a. "wheel") that was pre-built with an old `setuptools` version back when it was uploaded in Jan. 2021. Installing this built distribution doesn't means `setup.py` doesn't have to be parsed again to build the package after downloading it, which is the step that's failing. (Though it will fail if you try to install the source distribution with `pip install --no-binary :all: PsychRNN`). Importantly however, **this will also stop working beginning in Jan. 2024**. The next major release of `pip` (v24.0) [will start enforcing valid specifiers](https://github.com/pypa/pip/issues/12063) just like `setuptools v61.0` did, a new release will need to be pushed to PyPI for users to continue to be able to install the package (with up-to-date `pip` versions).

#

This PR is a minimal change but should fix all of these issues. 

Note the [`python_requires`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires) argument added to `setup.py` *does technically* impose minimum version requirements on both `setuptools` (`>=24.2.0`) and `pip` (`>=9.0.0`), however both of these versions were released >7 years ago, and any Python versions that could possibly still be using anything older are [long since EOL](https://devguide.python.org/versions/).

Thanks again, and hope this is helpful!